### PR TITLE
Add support for VE Framework

### DIFF
--- a/About/About.xml
+++ b/About/About.xml
@@ -31,6 +31,7 @@ Safe to add/remove anytime
 
 - Added support for [url=https://steamcommunity.com/sharedfiles/filedetails/?id=1776143665]Raise The Roof[/url]
 - Added support for drone-mining in most droid-mods.
+- Added support for chunks dug up by Vanilla Framework Expanded-based modded creatures (Stonedigger Dryads, etc).
 
 [h3]Deep drill[/h3]
 Chunks spawn on a random place around the miner there is no simple way of knowing if they spawned from the miner.

--- a/LoadFolders.xml
+++ b/LoadFolders.xml
@@ -22,5 +22,6 @@
     <li>/</li>
     <li>1.5</li>
     <li IfModActive="machine.rtr">Compatibility/RaiseTheRoof/1.5</li>
+    <li IfModActive="oskarpotocki.vanillafactionsexpanded.core">Compatibility/VanillaExpandedFramework/1.5</li>
   </v1.5>
 </loadFolders>

--- a/Source/HaulMinedChunks.sln
+++ b/Source/HaulMinedChunks.sln
@@ -5,7 +5,9 @@ VisualStudioVersion = 17.1.32421.90
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "HaulMinedChunks", "HaulMinedChunks\HaulMinedChunks.csproj", "{3E06096B-8065-4F25-805B-71CBB5E9C42F}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RaiseTheRoofPatch", "RaiseTheRoof\RaiseTheRoofPatch.csproj", "{E85A0F51-06DE-43AD-8130-06CDED33A9FF}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "RaiseTheRoofPatch", "RaiseTheRoof\RaiseTheRoofPatch.csproj", "{E85A0F51-06DE-43AD-8130-06CDED33A9FF}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "VanillaExpandedFrameworkPatch", "VanillaExpandedFramework\VanillaExpandedFrameworkPatch.csproj", "{51C6767B-3A78-4DCD-97FF-F5D5E7B5F97C}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -21,6 +23,10 @@ Global
 		{E85A0F51-06DE-43AD-8130-06CDED33A9FF}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{E85A0F51-06DE-43AD-8130-06CDED33A9FF}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{E85A0F51-06DE-43AD-8130-06CDED33A9FF}.Release|Any CPU.Build.0 = Release|Any CPU
+		{51C6767B-3A78-4DCD-97FF-F5D5E7B5F97C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{51C6767B-3A78-4DCD-97FF-F5D5E7B5F97C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{51C6767B-3A78-4DCD-97FF-F5D5E7B5F97C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{51C6767B-3A78-4DCD-97FF-F5D5E7B5F97C}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Source/VanillaExpandedFramework/CodeMatcherExtensions.cs
+++ b/Source/VanillaExpandedFramework/CodeMatcherExtensions.cs
@@ -1,0 +1,15 @@
+﻿using HarmonyLib;
+
+namespace HaulMinedChunks;
+
+public static class CodeMatcherExtensions
+{
+    public static CodeMatcher DuplicateInstruction(this CodeMatcher cm, int offset = 0)
+    {
+        return cm.Insert(cm.InstructionAt(offset));
+    }
+    public static CodeMatcher DuplicateInstructionAndAdvance(this CodeMatcher cm, int offset = 0)
+    {
+        return cm.InsertAndAdvance(cm.InstructionAt(offset));
+    }
+}

--- a/Source/VanillaExpandedFramework/CompDigPeriodically_Patches.cs
+++ b/Source/VanillaExpandedFramework/CompDigPeriodically_Patches.cs
@@ -1,0 +1,42 @@
+﻿using AnimalBehaviours;
+using HarmonyLib;
+using RimWorld;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection.Emit;
+using Verse;
+
+namespace HaulMinedChunks;
+
+[HarmonyPatch]
+public static class CompDigPeriodically_Patches
+{
+    [HarmonyPatch(typeof(CompDigPeriodically), nameof(CompDigPeriodically.CompTick))]
+    [HarmonyTranspiler]
+    public static IEnumerable<CodeInstruction> CompDigPeriodically_CompTick_Transpiler(IEnumerable<CodeInstruction> instructions)
+    {
+        return new CodeMatcher(instructions)
+            .MatchStartForward(
+                new CodeMatch(OpCodes.Ldloc_S), // Ld `thing`
+                new CodeMatch(OpCodes.Ldloc_S), // Ld `digIfRocksOrBricks`
+                new CodeMatch(OpCodes.Stfld, AccessTools.Field(typeof(Thing), nameof(Thing.stackCount))))
+            .DuplicateInstructionAndAdvance() // Duplicate the Ld `thing`
+            .Insert(CodeInstruction.Call(typeof(CompDigPeriodically_Patches), nameof(MarkToHaulIfHaulable)))
+            .InstructionEnumeration();
+    }
+
+    public static void MarkToHaulIfHaulable(Thing thing)
+    {
+        if (thing == null
+            || thing.Map == null
+            || thing.def.thingCategories?.Cross(HaulMinedChunks.ChunkCategoryDefs).Any() == false)
+        {
+            return;
+        }
+
+        if (HaulMinedChunks.ShouldMarkChunk(thing.Position, thing.Map))
+        {
+            thing.Map.designationManager.AddDesignation(new Designation(thing, DesignationDefOf.Haul));
+        }
+    }
+}

--- a/Source/VanillaExpandedFramework/VanillaExpandedFrameworkPatch.cs
+++ b/Source/VanillaExpandedFramework/VanillaExpandedFrameworkPatch.cs
@@ -1,0 +1,14 @@
+﻿using HarmonyLib;
+using Verse;
+
+namespace HaulMinedChunks;
+
+[StaticConstructorOnStartup]
+public class VanillaExpandedFrameworkPatch
+{
+    static VanillaExpandedFrameworkPatch()
+    {
+        new Harmony("Mlie.HaulMinedChunks.VanillaExpandedFrameworkPatch").PatchAll();
+        Log.Message("[HaulMinedChunks]: Adding compatibility with Vanilla Expanded Framework");
+    }
+}

--- a/Source/VanillaExpandedFramework/VanillaExpandedFrameworkPatch.csproj
+++ b/Source/VanillaExpandedFramework/VanillaExpandedFrameworkPatch.csproj
@@ -1,0 +1,33 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputPath>..\..\Compatibility\VanillaExpandedFramework\1.5\Assemblies</OutputPath>
+    <TargetFramework>net48</TargetFramework>
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+    <AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
+    <DebugType>None</DebugType>
+    <LangVersion>latest</LangVersion>
+    <FileVersion>1.5.1</FileVersion>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Krafs.Rimworld.Ref">
+      <Version>*</Version>
+      <ExcludeAssets>runtime</ExcludeAssets>
+      <IncludeAssets>compile; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Lib.Harmony">
+      <Version>*</Version>
+      <ExcludeAssets>runtime</ExcludeAssets>
+    </PackageReference>
+    <ProjectReference Include="..\HaulMinedChunks\HaulMinedChunks.csproj">
+      <CopyLocalSatelliteAssemblies>False</CopyLocalSatelliteAssemblies>
+      <CopyLocal>False</CopyLocal>
+      <Private>false</Private>
+      <ExcludeAssets>all</ExcludeAssets>
+    </ProjectReference>
+    <Reference Include="VFECore">
+      <HintPath>..\..\..\..\..\..\workshop\content\294100\2023507013\1.5\Assemblies\VFECore.dll</HintPath>
+      <CopyLocal>False</CopyLocal>
+      <Private>false</Private>
+    </Reference>
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
I slightly re-worked the patch I've had running locally since the VE Dryads were added so it would fit more here. This version uses the `HaulMinedChunks.ShouldMarkChunk` and `HaulMinedChunks.ChunkCategoryDefs` references from the base mod to determine whether the `thing` should be marked, instead of just always doing it if it is Haulable at all.

The transpiler looks for a single spot in the VEFramework `Comp` where it is only digging either a rock or bricks, so it needs to check if it's actually a chunk, but this code won't execute in the case of it digging up food or whatever like some other animals do.

![image](https://github.com/emipa606/HaulMinedChunks/assets/5238335/d07a52d1-cd7b-42ca-be0a-245f31402d45)

It's inserting right above setting the stackCount, but that doesn't really matter because the `thing` has already been placed, and designating Haulable doesn't care about the stackCount.

Below I've attached a save file (using VEFramework, Vanilla Ideology Expanded - Dryads (for the stonediggers), and this mod) that you can load up if you want to see the functionality working. There's already three stonediggers spawned and the area is cleared of chunks so that it's easy to see that when they appear, they are already marked for hauling. 

[stonedigger_haulable_test_wait.zip](https://github.com/user-attachments/files/15523078/stonedigger_haulable_test_wait.zip)

If you're interested, I looked into it and I think I can get Deep Drills to get auto-marked in the same way by Transpiling `CompDeepDrill` near it's call to `TryPlaceThing`. Let me know if you'd be interested and I'll take a look at doing that as well, though that'll require a little bit more testing locally on my part since I won't have had that patch running for a couple years before submitting it 😆 
