### PR TITLE
Add support for chunks from Deep Drills

### DIFF
--- a/Source/HaulMinedChunks/CompDeepDrill_TryProducePortion.cs
+++ b/Source/HaulMinedChunks/CompDeepDrill_TryProducePortion.cs
@@ -1,0 +1,49 @@
+﻿using HarmonyLib;
+using RimWorld;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection.Emit;
+using Verse;
+
+namespace HaulMinedChunks;
+
+[HarmonyPatch(typeof(CompDeepDrill), "TryProducePortion")]
+internal class CompDeepDrill_TryProducePortion
+{
+    private static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions)
+    {
+        var makeThingMethod = AccessTools.Method(typeof(ThingMaker), nameof(ThingMaker.MakeThing), [typeof(ThingDef), typeof(ThingDef)]);
+        var tryPlaceThingMethod = AccessTools.Method(typeof(GenPlace), nameof(GenPlace.TryPlaceThing), [typeof(Thing), typeof(IntVec3), typeof(Map), typeof(ThingPlaceMode), typeof(Action<Thing, int>), typeof(Predicate<IntVec3>), typeof(Rot4)]);
+        var markToHaulMethod = AccessTools.Method(typeof(CompDeepDrill_TryProducePortion), nameof(TryMarkToHaul));
+
+        return new CodeMatcher(instructions)
+            .MatchStartForward(
+                new CodeMatch(OpCodes.Call, makeThingMethod))
+            .ThrowIfInvalid("MakeThing location not found.")
+            .Advance(1)
+            .Insert(new CodeInstruction(OpCodes.Dup)) //Insert another reference to `thing` to use later.
+            .MatchStartForward(
+                new CodeMatch(OpCodes.Call, tryPlaceThingMethod),
+                new CodeMatch(OpCodes.Pop))
+            .ThrowIfInvalid("TryPlaceThing location not found.")
+            .Advance(1)
+            .SetAndAdvance(OpCodes.Call, markToHaulMethod) // Replace the pop with a call to our method, so we pass the bool from TryPlaceThing as a parameter, using the dup'd `thing` from earlier.
+            .InstructionEnumeration();
+    }
+
+    public static void TryMarkToHaul(Thing thing, bool created)
+    {
+        if (!created
+            || thing?.Map == null
+            || thing.def.thingCategories?.Intersect(HaulMinedChunks.ChunkCategoryDefs).Any() == false)
+        {
+            return;
+        }
+
+        if (HaulMinedChunks.ShouldMarkChunk(thing.Position, thing.Map))
+        {
+            thing.Map.designationManager.AddDesignation(new Designation(thing, DesignationDefOf.Haul));
+        }
+    }
+}

--- a/Source/HaulMinedChunks/Mineable_TrySpawnYield.cs
+++ b/Source/HaulMinedChunks/Mineable_TrySpawnYield.cs
@@ -17,7 +17,7 @@ internal class Mineable_TrySpawnYield
 
         var possibleChunk = __instance.Position.GetFirstHaulable(map);
         if (possibleChunk == null ||
-            possibleChunk.def.thingCategories?.Cross(HaulMinedChunks.ChunkCategoryDefs).Any() == false)
+            possibleChunk.def.thingCategories?.Intersect(HaulMinedChunks.ChunkCategoryDefs).Any() == false)
         {
             return;
         }

--- a/Source/VanillaExpandedFramework/CompDigPeriodically_CompTick.cs
+++ b/Source/VanillaExpandedFramework/CompDigPeriodically_CompTick.cs
@@ -27,7 +27,7 @@ public static class CompDigPeriodically_CompTick
     public static void MarkToHaulIfHaulable(Thing thing)
     {
         if (thing?.Map == null
-            || thing.def.thingCategories?.Cross(HaulMinedChunks.ChunkCategoryDefs).Any() == false)
+            || thing.def.thingCategories?.Intersect(HaulMinedChunks.ChunkCategoryDefs).Any() == false)
         {
             return;
         }


### PR DESCRIPTION
Adds a transpiler on `CompDeepDrill`'s `TryProducePortion` method. Inserts minor code in two places in the method.

![image](https://github.com/emipa606/HaulMinedChunks/assets/5238335/7aaea298-947d-42b2-adea-e8f5c677c6f6)

(1) is a change to add an extra `dup` after `MakeThing` is called. This is because the `thing` returned from that method isn't saved into a variable locally by the compiler. It loads two copies onto the stack and uses them immediately. We add an extra `dup` call to load a third, and consume it via the call in (2).

(2) replaces the `pop` after `TryPlaceThing`. The `pop` is there because the `bool` return from `TryPlaceThing` isn't used by the method. I repurpose that `bool` by passing it, along with the `dup`'d `thing` from (1) into the new check method. 

That `bool` is a "was the thing placed onto the map" check. If it's true, and the thing is a chunk that should be hauled, then we mark it to be hauled.

While working on this, I found out that `Cross` was not the right method for checking if two lists contain a shared item (which I think is the logic we want here). I don't know if maybe it worked differently previously, but what it led to in 1.5 is that it's always returning values as long as neither of the lists are empty.

I changed all uses of `Cross` to `Intersect`. This is doing what (I think) we want, and returning all `ThingCategoryDef`'s that are _shared_ between both lists. If there is at least one category shared, then it's allowed to pass.

Attaching another save file with three deep drills forbidden at ~90%. One is just on stone, which should get marked for hauling, and one each on Steel and Uranium which shouldn't. 
[deep_drill_test_2.zip](https://github.com/user-attachments/files/15528368/deep_drill_test_2.zip)

I didn't re-test RaiseTheRoof because I've never used that mod, but I did re-test the dryad's save I had from yesterday and it's working as expected there as well.
